### PR TITLE
Sermon on the Mount: Differences between New Testament and Book of Mormon

### DIFF
--- a/sermon-mount.txt
+++ b/sermon-mount.txt
@@ -1,215 +1,215 @@
- And it came to pass that when Jesus had spoken these words unto Nephi, and to those who had been called, (now the number of them who had been called, and received power and authority to baptize, was twelve) and behold, he stretched forth his hand unto the multitude, and cried unto them, saying: Blessed are ye if ye shall give heed unto the words of these twelve whom I have chosen from among you to minister unto you, and to be your servants; and unto them I have given power that they may baptize you with water; and after that ye are baptized with water, behold, I will baptize you with fire and with the Holy Ghost; therefore blessed are ye if ye shall believe in me and be baptized, after that ye have seen me and know that I am.
+And it came to pass that when Jesus had spoken these words unto Nephi, and to those who had been called, (now the number of them who had been called, and received power and authority to baptize, was twelve) and behold, he stretched forth his hand unto the multitude, and cried unto them, saying: Blessed are ye if ye shall give heed unto the words of these twelve whom I have chosen from among you to minister unto you, and to be your servants; and unto them I have given power that they may baptize you with water; and after that ye are baptized with water, behold, I will baptize you with fire and with the Holy Ghost; therefore blessed are ye if ye shall believe in me and be baptized, after that ye have seen me and know that I am.
 
- And again, more blessed are they who shall believe in your words because that ye shall testify that ye have seen me, and that ye know that I am. Yea, blessed are they who shall believe in your words, and come down into the depths of humility and be baptized, for they shall be visited with fire and with the Holy Ghost, and shall receive a remission of their sins.
+And again, more blessed are they who shall believe in your words because that ye shall testify that ye have seen me, and that ye know that I am. Yea, blessed are they who shall believe in your words, and come down into the depths of humility and be baptized, for they shall be visited with fire and with the Holy Ghost, and shall receive a remission of their sins.
 
- Yea, blessed are the poor in spirit who come unto me, for theirs is the kingdom of heaven.
+Yea, blessed are the poor in spirit who come unto me, for theirs is the kingdom of heaven.
 
- And again, blessed are all they that mourn, for they shall be comforted.
+And again, blessed are all they that mourn, for they shall be comforted.
 
- And blessed are the meek, for they shall inherit the earth.
+And blessed are the meek, for they shall inherit the earth.
 
- And blessed are all they who do hunger and thirst after righteousness, for they shall be filled with the Holy Ghost.
+And blessed are all they who do hunger and thirst after righteousness, for they shall be filled with the Holy Ghost.
 
- And blessed are the merciful, for they shall obtain mercy.
+And blessed are the merciful, for they shall obtain mercy.
 
- And blessed are all the pure in heart, for they shall see God.
+And blessed are all the pure in heart, for they shall see God.
 
- And blessed are all the peacemakers, for they shall be called the children of God.
+And blessed are all the peacemakers, for they shall be called the children of God.
 
- And blessed are all they who are persecuted for my name’s sake, for theirs is the kingdom of heaven.
+And blessed are all they who are persecuted for my name’s sake, for theirs is the kingdom of heaven.
 
- And blessed are ye when men shall revile you and persecute, and shall say all manner of evil against you falsely, for my sake;
+And blessed are ye when men shall revile you and persecute, and shall say all manner of evil against you falsely, for my sake;
 
- For ye shall have great joy and be exceedingly glad, for great shall be your reward in heaven; for so persecuted they the prophets who were before you.
+For ye shall have great joy and be exceedingly glad, for great shall be your reward in heaven; for so persecuted they the prophets who were before you.
 
- Verily, verily, I say unto you, I give unto you to be the salt of the earth; but if the salt shall lose its savor wherewith shall the earth be salted? The salt shall be thenceforth good for nothing, but to be cast out and to be trodden under foot of men.
+Verily, verily, I say unto you, I give unto you to be the salt of the earth; but if the salt shall lose its savor wherewith shall the earth be salted? The salt shall be thenceforth good for nothing, but to be cast out and to be trodden under foot of men.
 
- Verily, verily, I say unto you, I give unto you to be the light of this people. A city that is set on a hill cannot be hid.
+Verily, verily, I say unto you, I give unto you to be the light of this people. A city that is set on a hill cannot be hid.
 
- Behold, do men light a candle and put it under a bushel? Nay, but on a candlestick, and it giveth light to all that are in the house;
+Behold, do men light a candle and put it under a bushel? Nay, but on a candlestick, and it giveth light to all that are in the house;
 
- Therefore let your light so shine before this people, that they may see your good works and glorify your Father who is in heaven.
+Therefore let your light so shine before this people, that they may see your good works and glorify your Father who is in heaven.
 
- Think not that I am come to destroy the law or the prophets. I am not come to destroy but to fulfil;
+Think not that I am come to destroy the law or the prophets. I am not come to destroy but to fulfil;
 
- For verily I say unto you, one jot nor one tittle hath not passed away from the law, but in me it hath all been fulfilled.
+For verily I say unto you, one jot nor one tittle hath not passed away from the law, but in me it hath all been fulfilled.
 
- And behold, I have given you the law and the commandments of my Father, that ye shall believe in me, and that ye shall repent of your sins, and come unto me with a broken heart and a contrite spirit. Behold, ye have the commandments before you, and the law is fulfilled.
+And behold, I have given you the law and the commandments of my Father, that ye shall believe in me, and that ye shall repent of your sins, and come unto me with a broken heart and a contrite spirit. Behold, ye have the commandments before you, and the law is fulfilled.
 
- Therefore come unto me and be ye saved; for verily I say unto you, that except ye shall keep my commandments, which I have commanded you at this time, ye shall in no case enter into the kingdom of heaven.
+Therefore come unto me and be ye saved; for verily I say unto you, that except ye shall keep my commandments, which I have commanded you at this time, ye shall in no case enter into the kingdom of heaven.
 
- Ye have heard that it hath been said by them of old time, and it is also written before you, that thou shalt not kill, and whosoever shall kill shall be in danger of the judgment of God;
+Ye have heard that it hath been said by them of old time, and it is also written before you, that thou shalt not kill, and whosoever shall kill shall be in danger of the judgment of God;
 
- But I say unto you, that whosoever is angry with his brother shall be in danger of his judgment. And whosoever shall say to his brother, Raca, shall be in danger of the council; and whosoever shall say, Thou fool, shall be in danger of hell fire.
+But I say unto you, that whosoever is angry with his brother shall be in danger of his judgment. And whosoever shall say to his brother, Raca, shall be in danger of the council; and whosoever shall say, Thou fool, shall be in danger of hell fire.
 
- Therefore, if ye shall come unto me, or shall desire to come unto me, and rememberest that thy brother hath aught against thee—
+Therefore, if ye shall come unto me, or shall desire to come unto me, and rememberest that thy brother hath aught against thee—
 
- Go thy way unto thy brother, and first be reconciled to thy brother, and then come unto me with full purpose of heart, and I will receive you.
+Go thy way unto thy brother, and first be reconciled to thy brother, and then come unto me with full purpose of heart, and I will receive you.
 
- Agree with thine adversary quickly while thou art in the way with him, lest at any time he shall get thee, and thou shalt be cast into prison.
+Agree with thine adversary quickly while thou art in the way with him, lest at any time he shall get thee, and thou shalt be cast into prison.
 
- Verily, verily, I say unto thee, thou shalt by no means come out thence until thou hast paid the uttermost senine. And while ye are in prison can ye pay even one senine? Verily, verily, I say unto you, Nay.
+Verily, verily, I say unto thee, thou shalt by no means come out thence until thou hast paid the uttermost senine. And while ye are in prison can ye pay even one senine? Verily, verily, I say unto you, Nay.
 
- Behold, it is written by them of old time, that thou shalt not commit adultery;
+Behold, it is written by them of old time, that thou shalt not commit adultery;
 
- But I say unto you, that whosoever looketh on a woman, to lust after her, hath committed adultery already in his heart.
+But I say unto you, that whosoever looketh on a woman, to lust after her, hath committed adultery already in his heart.
 
- Behold, I give unto you a commandment, that ye suffer none of these things to enter into your heart;
+Behold, I give unto you a commandment, that ye suffer none of these things to enter into your heart;
 
- For it is better that ye should deny yourselves of these things, wherein ye will take up your cross, than that ye should be cast into hell.
+For it is better that ye should deny yourselves of these things, wherein ye will take up your cross, than that ye should be cast into hell.
 
- It hath been written, that whosoever shall put away his wife, let him give her a writing of divorcement.
+It hath been written, that whosoever shall put away his wife, let him give her a writing of divorcement.
 
- Verily, verily, I say unto you, that whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery; and whoso shall marry her who is divorced committeth adultery.
+Verily, verily, I say unto you, that whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery; and whoso shall marry her who is divorced committeth adultery.
 
- And again it is written, thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths;
+And again it is written, thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths;
 
- But verily, verily, I say unto you, swear not at all; neither by heaven, for it is God’s throne;
+But verily, verily, I say unto you, swear not at all; neither by heaven, for it is God’s throne;
 
- Nor by the earth, for it is his footstool;
+Nor by the earth, for it is his footstool;
 
- Neither shalt thou swear by thy head, because thou canst not make one hair black or white;
+Neither shalt thou swear by thy head, because thou canst not make one hair black or white;
 
- But let your communication be Yea, yea; Nay, nay; for whatsoever cometh of more than these is evil.
+But let your communication be Yea, yea; Nay, nay; for whatsoever cometh of more than these is evil.
 
- And behold, it is written, an eye for an eye, and a tooth for a tooth;
+And behold, it is written, an eye for an eye, and a tooth for a tooth;
 
- But I say unto you, that ye shall not resist evil, but whosoever shall smite thee on thy right cheek, turn to him the other also;
+But I say unto you, that ye shall not resist evil, but whosoever shall smite thee on thy right cheek, turn to him the other also;
 
- And if any man will sue thee at the law and take away thy coat, let him have thy cloak also;
+And if any man will sue thee at the law and take away thy coat, let him have thy cloak also;
 
- And whosoever shall compel thee to go a mile, go with him twain.
+And whosoever shall compel thee to go a mile, go with him twain.
 
- Give to him that asketh thee, and from him that would borrow of thee turn thou not away.
+Give to him that asketh thee, and from him that would borrow of thee turn thou not away.
 
- And behold it is written also, that thou shalt love thy neighbor and hate thine enemy;
+And behold it is written also, that thou shalt love thy neighbor and hate thine enemy;
 
- But behold I say unto you, love your enemies, bless them that curse you, do good to them that hate you, and pray for them who despitefully use you and persecute you;
+But behold I say unto you, love your enemies, bless them that curse you, do good to them that hate you, and pray for them who despitefully use you and persecute you;
 
- That ye may be the children of your Father who is in heaven; for he maketh his sun to rise on the evil and on the good.
+That ye may be the children of your Father who is in heaven; for he maketh his sun to rise on the evil and on the good.
 
- Therefore those things which were of old time, which were under the law, in me are all fulfilled.
+Therefore those things which were of old time, which were under the law, in me are all fulfilled.
 
- Old things are done away, and all things have become new.
+Old things are done away, and all things have become new.
 
- Therefore I would that ye should be perfect even as I, or your Father who is in heaven is perfect. Verily, verily, I say that I would that ye should do alms unto the poor; but take heed that ye do not your alms before men to be seen of them; otherwise ye have no reward of your Father who is in heaven.
+Therefore I would that ye should be perfect even as I, or your Father who is in heaven is perfect. Verily, verily, I say that I would that ye should do alms unto the poor; but take heed that ye do not your alms before men to be seen of them; otherwise ye have no reward of your Father who is in heaven.
 
- Therefore, when ye shall do your alms do not sound a trumpet before you, as will hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, they have their reward.
+Therefore, when ye shall do your alms do not sound a trumpet before you, as will hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, they have their reward.
 
- But when thou doest alms let not thy left hand know what thy right hand doeth;
+But when thou doest alms let not thy left hand know what thy right hand doeth;
 
- That thine alms may be in secret; and thy Father who seeth in secret, himself shall reward thee openly.
+That thine alms may be in secret; and thy Father who seeth in secret, himself shall reward thee openly.
 
- And when thou prayest thou shalt not do as the hypocrites, for they love to pray, standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, they have their reward.
+And when thou prayest thou shalt not do as the hypocrites, for they love to pray, standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, they have their reward.
 
- But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
+But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
 
- But when ye pray, use not vain repetitions, as the heathen, for they think that they shall be heard for their much speaking.
+But when ye pray, use not vain repetitions, as the heathen, for they think that they shall be heard for their much speaking.
 
- Be not ye therefore like unto them, for your Father knoweth what things ye have need of before ye ask him.
+Be not ye therefore like unto them, for your Father knoweth what things ye have need of before ye ask him.
 
- After this manner therefore pray ye: Our Father who art in heaven, hallowed be thy name.
+After this manner therefore pray ye: Our Father who art in heaven, hallowed be thy name.
 
- Thy will be done on earth as it is in heaven.
+Thy will be done on earth as it is in heaven.
 
- And forgive us our debts, as we forgive our debtors.
+And forgive us our debts, as we forgive our debtors.
 
- And lead us not into temptation, but deliver us from evil.
+And lead us not into temptation, but deliver us from evil.
 
- For thine is the kingdom, and the power, and the glory, forever. Amen.
+For thine is the kingdom, and the power, and the glory, forever. Amen.
 
- For, if ye forgive men their trespasses your heavenly Father will also forgive you;
+For, if ye forgive men their trespasses your heavenly Father will also forgive you;
 
- But if ye forgive not men their trespasses neither will your Father forgive your trespasses.
+But if ye forgive not men their trespasses neither will your Father forgive your trespasses.
 
- Moreover, when ye fast be not as the hypocrites, of a sad countenance, for they disfigure their faces that they may appear unto men to fast. Verily I say unto you, they have their reward.
+Moreover, when ye fast be not as the hypocrites, of a sad countenance, for they disfigure their faces that they may appear unto men to fast. Verily I say unto you, they have their reward.
 
- But thou, when thou fastest, anoint thy head, and wash thy face;
+But thou, when thou fastest, anoint thy head, and wash thy face;
 
- That thou appear not unto men to fast, but unto thy Father, who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
+That thou appear not unto men to fast, but unto thy Father, who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
 
- Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and thieves break through and steal;
+Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and thieves break through and steal;
 
- But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal.
+But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal.
 
- For where your treasure is, there will your heart be also.
+For where your treasure is, there will your heart be also.
 
- The light of the body is the eye; if, therefore, thine eye be single, thy whole body shall be full of light.
+The light of the body is the eye; if, therefore, thine eye be single, thy whole body shall be full of light.
 
- But if thine eye be evil, thy whole body shall be full of darkness. If, therefore, the light that is in thee be darkness, how great is that darkness!
+But if thine eye be evil, thy whole body shall be full of darkness. If, therefore, the light that is in thee be darkness, how great is that darkness!
 
- No man can serve two masters; for either he will hate the one and love the other, or else he will hold to the one and despise the other. Ye cannot serve God and Mammon.
+No man can serve two masters; for either he will hate the one and love the other, or else he will hold to the one and despise the other. Ye cannot serve God and Mammon.
 
- And now it came to pass that when Jesus had spoken these words he looked upon the twelve whom he had chosen, and said unto them: Remember the words which I have spoken. For behold, ye are they whom I have chosen to minister unto this people. Therefore I say unto you, take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
+And now it came to pass that when Jesus had spoken these words he looked upon the twelve whom he had chosen, and said unto them: Remember the words which I have spoken. For behold, ye are they whom I have chosen to minister unto this people. Therefore I say unto you, take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
 
- Behold the fowls of the air, for they sow not, neither do they reap nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
+Behold the fowls of the air, for they sow not, neither do they reap nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
 
- Which of you by taking thought can add one cubit unto his stature?
+Which of you by taking thought can add one cubit unto his stature?
 
- And why take ye thought for raiment? Consider the lilies of the field how they grow; they toil not, neither do they spin;
+And why take ye thought for raiment? Consider the lilies of the field how they grow; they toil not, neither do they spin;
 
- And yet I say unto you, that even Solomon, in all his glory, was not arrayed like one of these.
+And yet I say unto you, that even Solomon, in all his glory, was not arrayed like one of these.
 
- Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, even so will he clothe you, if ye are not of little faith.
+Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, even so will he clothe you, if ye are not of little faith.
 
- Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
+Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
 
- For your heavenly Father knoweth that ye have need of all these things.
+For your heavenly Father knoweth that ye have need of all these things.
 
- But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
+But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
 
- Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.
+Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.
 
- And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
+And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
 
- For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
+For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
 
- And why beholdest thou the mote that is in thy brother’s eye, but considerest not the beam that is in thine own eye?
+And why beholdest thou the mote that is in thy brother’s eye, but considerest not the beam that is in thine own eye?
 
- Or how wilt thou say to thy brother: Let me pull the mote out of thine eye—and behold, a beam is in thine own eye?
+Or how wilt thou say to thy brother: Let me pull the mote out of thine eye—and behold, a beam is in thine own eye?
 
- Thou hypocrite, first cast the beam out of thine own eye; and then shalt thou see clearly to cast the mote out of thy brother’s eye.
+Thou hypocrite, first cast the beam out of thine own eye; and then shalt thou see clearly to cast the mote out of thy brother’s eye.
 
- Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
+Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
 
- Ask, and it shall be given unto you; seek, and ye shall find; knock, and it shall be opened unto you.
+Ask, and it shall be given unto you; seek, and ye shall find; knock, and it shall be opened unto you.
 
- For every one that asketh, receiveth; and he that seeketh, findeth; and to him that knocketh, it shall be opened.
+For every one that asketh, receiveth; and he that seeketh, findeth; and to him that knocketh, it shall be opened.
 
- Or what man is there of you, who, if his son ask bread, will give him a stone?
+Or what man is there of you, who, if his son ask bread, will give him a stone?
 
- Or if he ask a fish, will he give him a serpent?
+Or if he ask a fish, will he give him a serpent?
 
- If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father who is in heaven give good things to them that ask him?
+If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father who is in heaven give good things to them that ask him?
 
- Therefore, all things whatsoever ye would that men should do to you, do ye even so to them, for this is the law and the prophets.
+Therefore, all things whatsoever ye would that men should do to you, do ye even so to them, for this is the law and the prophets.
 
- Enter ye in at the strait gate; for wide is the gate, and broad is the way, which leadeth to destruction, and many there be who go in thereat;
+Enter ye in at the strait gate; for wide is the gate, and broad is the way, which leadeth to destruction, and many there be who go in thereat;
 
- Because strait is the gate, and narrow is the way, which leadeth unto life, and few there be that find it.
+Because strait is the gate, and narrow is the way, which leadeth unto life, and few there be that find it.
 
- Beware of false prophets, who come to you in sheep’s clothing, but inwardly they are ravening wolves.
+Beware of false prophets, who come to you in sheep’s clothing, but inwardly they are ravening wolves.
 
- Ye shall know them by their fruits. Do men gather grapes of thorns, or figs of thistles?
+Ye shall know them by their fruits. Do men gather grapes of thorns, or figs of thistles?
 
- Even so every good tree bringeth forth good fruit; but a corrupt tree bringeth forth evil fruit.
+Even so every good tree bringeth forth good fruit; but a corrupt tree bringeth forth evil fruit.
 
- A good tree cannot bring forth evil fruit, neither a corrupt tree bring forth good fruit.
+A good tree cannot bring forth evil fruit, neither a corrupt tree bring forth good fruit.
 
- Every tree that bringeth not forth good fruit is hewn down, and cast into the fire.
+Every tree that bringeth not forth good fruit is hewn down, and cast into the fire.
 
- Wherefore, by their fruits ye shall know them.
+Wherefore, by their fruits ye shall know them.
 
- Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father who is in heaven.
+Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father who is in heaven.
 
- Many will say to me in that day: Lord, Lord, have we not prophesied in thy name, and in thy name have cast out devils, and in thy name done many wonderful works?
+Many will say to me in that day: Lord, Lord, have we not prophesied in thy name, and in thy name have cast out devils, and in thy name done many wonderful works?
 
- And then will I profess unto them: I never knew you; depart from me, ye that work iniquity.
+And then will I profess unto them: I never knew you; depart from me, ye that work iniquity.
 
- Therefore, whoso heareth these sayings of mine and doeth them, I will liken him unto a wise man, who built his house upon a rock—
+Therefore, whoso heareth these sayings of mine and doeth them, I will liken him unto a wise man, who built his house upon a rock—
 
- And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not, for it was founded upon a rock.
+And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not, for it was founded upon a rock.
 
- And every one that heareth these sayings of mine and doeth them not shall be likened unto a foolish man, who built his house upon the sand—
+And every one that heareth these sayings of mine and doeth them not shall be likened unto a foolish man, who built his house upon the sand—
 
- And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell, and great was the fall of it.
+And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell, and great was the fall of it.

--- a/sermon-mount.txt
+++ b/sermon-mount.txt
@@ -1,109 +1,215 @@
 And it came to pass that when Jesus had spoken these words unto Nephi, and to those who had been called, (now the number of them who had been called, and received power and authority to baptize, was twelve) and behold, he stretched forth his hand unto the multitude, and cried unto them, saying: Blessed are ye if ye shall give heed unto the words of these twelve whom I have chosen from among you to minister unto you, and to be your servants; and unto them I have given power that they may baptize you with water; and after that ye are baptized with water, behold, I will baptize you with fire and with the Holy Ghost; therefore blessed are ye if ye shall believe in me and be baptized, after that ye have seen me and know that I am.
+
 And again, more blessed are they who shall believe in your words because that ye shall testify that ye have seen me, and that ye know that I am. Yea, blessed are they who shall believe in your words, and come down into the depths of humility and be baptized, for they shall be visited with fire and with the Holy Ghost, and shall receive a remission of their sins.
+
 Yea, blessed are the poor in spirit who come unto me, for theirs is the kingdom of heaven.
+
 And again, blessed are all they that mourn, for they shall be comforted.
+
 And blessed are the meek, for they shall inherit the earth.
+
 And blessed are all they who do hunger and thirst after righteousness, for they shall be filled with the Holy Ghost.
+
 And blessed are the merciful, for they shall obtain mercy.
+
 And blessed are all the pure in heart, for they shall see God.
+
 And blessed are all the peacemakers, for they shall be called the children of God.
+
 And blessed are all they who are persecuted for my name’s sake, for theirs is the kingdom of heaven.
+
 And blessed are ye when men shall revile you and persecute, and shall say all manner of evil against you falsely, for my sake;
+
 For ye shall have great joy and be exceedingly glad, for great shall be your reward in heaven; for so persecuted they the prophets who were before you.
+
 Verily, verily, I say unto you, I give unto you to be the salt of the earth; but if the salt shall lose its savor wherewith shall the earth be salted? The salt shall be thenceforth good for nothing, but to be cast out and to be trodden under foot of men.
+
 Verily, verily, I say unto you, I give unto you to be the light of this people. A city that is set on a hill cannot be hid.
+
 Behold, do men light a candle and put it under a bushel? Nay, but on a candlestick, and it giveth light to all that are in the house;
+
 Therefore let your light so shine before this people, that they may see your good works and glorify your Father who is in heaven.
+
 Think not that I am come to destroy the law or the prophets. I am not come to destroy but to fulfil;
+
 For verily I say unto you, one jot nor one tittle hath not passed away from the law, but in me it hath all been fulfilled.
+
 And behold, I have given you the law and the commandments of my Father, that ye shall believe in me, and that ye shall repent of your sins, and come unto me with a broken heart and a contrite spirit. Behold, ye have the commandments before you, and the law is fulfilled.
+
 Therefore come unto me and be ye saved; for verily I say unto you, that except ye shall keep my commandments, which I have commanded you at this time, ye shall in no case enter into the kingdom of heaven.
+
 Ye have heard that it hath been said by them of old time, and it is also written before you, that thou shalt not kill, and whosoever shall kill shall be in danger of the judgment of God;
+
 But I say unto you, that whosoever is angry with his brother shall be in danger of his judgment. And whosoever shall say to his brother, Raca, shall be in danger of the council; and whosoever shall say, Thou fool, shall be in danger of hell fire.
+
 Therefore, if ye shall come unto me, or shall desire to come unto me, and rememberest that thy brother hath aught against thee—
+
 Go thy way unto thy brother, and first be reconciled to thy brother, and then come unto me with full purpose of heart, and I will receive you.
+
 Agree with thine adversary quickly while thou art in the way with him, lest at any time he shall get thee, and thou shalt be cast into prison.
+
 Verily, verily, I say unto thee, thou shalt by no means come out thence until thou hast paid the uttermost senine. And while ye are in prison can ye pay even one senine? Verily, verily, I say unto you, Nay.
+
 Behold, it is written by them of old time, that thou shalt not commit adultery;
+
 But I say unto you, that whosoever looketh on a woman, to lust after her, hath committed adultery already in his heart.
+
 Behold, I give unto you a commandment, that ye suffer none of these things to enter into your heart;
+
 For it is better that ye should deny yourselves of these things, wherein ye will take up your cross, than that ye should be cast into hell.
+
 It hath been written, that whosoever shall put away his wife, let him give her a writing of divorcement.
+
 Verily, verily, I say unto you, that whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery; and whoso shall marry her who is divorced committeth adultery.
+
 And again it is written, thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths;
+
 But verily, verily, I say unto you, swear not at all; neither by heaven, for it is God’s throne;
+
 Nor by the earth, for it is his footstool;
+
 Neither shalt thou swear by thy head, because thou canst not make one hair black or white;
+
 But let your communication be Yea, yea; Nay, nay; for whatsoever cometh of more than these is evil.
+
 And behold, it is written, an eye for an eye, and a tooth for a tooth;
+
 But I say unto you, that ye shall not resist evil, but whosoever shall smite thee on thy right cheek, turn to him the other also;
+
 And if any man will sue thee at the law and take away thy coat, let him have thy cloak also;
+
 And whosoever shall compel thee to go a mile, go with him twain.
+
 Give to him that asketh thee, and from him that would borrow of thee turn thou not away.
+
 And behold it is written also, that thou shalt love thy neighbor and hate thine enemy;
+
 But behold I say unto you, love your enemies, bless them that curse you, do good to them that hate you, and pray for them who despitefully use you and persecute you;
+
 That ye may be the children of your Father who is in heaven; for he maketh his sun to rise on the evil and on the good.
+
 Therefore those things which were of old time, which were under the law, in me are all fulfilled.
+
 Old things are done away, and all things have become new.
+
 Therefore I would that ye should be perfect even as I, or your Father who is in heaven is perfect. Verily, verily, I say that I would that ye should do alms unto the poor; but take heed that ye do not your alms before men to be seen of them; otherwise ye have no reward of your Father who is in heaven.
+
 Therefore, when ye shall do your alms do not sound a trumpet before you, as will hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, they have their reward.
+
 But when thou doest alms let not thy left hand know what thy right hand doeth;
+
 That thine alms may be in secret; and thy Father who seeth in secret, himself shall reward thee openly.
+
 And when thou prayest thou shalt not do as the hypocrites, for they love to pray, standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, they have their reward.
+
 But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
+
 But when ye pray, use not vain repetitions, as the heathen, for they think that they shall be heard for their much speaking.
+
 Be not ye therefore like unto them, for your Father knoweth what things ye have need of before ye ask him.
+
 After this manner therefore pray ye: Our Father who art in heaven, hallowed be thy name.
+
 Thy will be done on earth as it is in heaven.
+
 And forgive us our debts, as we forgive our debtors.
+
 And lead us not into temptation, but deliver us from evil.
+
 For thine is the kingdom, and the power, and the glory, forever. Amen.
+
 For, if ye forgive men their trespasses your heavenly Father will also forgive you;
+
 But if ye forgive not men their trespasses neither will your Father forgive your trespasses.
+
 Moreover, when ye fast be not as the hypocrites, of a sad countenance, for they disfigure their faces that they may appear unto men to fast. Verily I say unto you, they have their reward.
+
 But thou, when thou fastest, anoint thy head, and wash thy face;
+
 That thou appear not unto men to fast, but unto thy Father, who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
+
 Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and thieves break through and steal;
+
 But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal.
+
 For where your treasure is, there will your heart be also.
+
 The light of the body is the eye; if, therefore, thine eye be single, thy whole body shall be full of light.
+
 But if thine eye be evil, thy whole body shall be full of darkness. If, therefore, the light that is in thee be darkness, how great is that darkness!
+
 No man can serve two masters; for either he will hate the one and love the other, or else he will hold to the one and despise the other. Ye cannot serve God and Mammon.
+
 And now it came to pass that when Jesus had spoken these words he looked upon the twelve whom he had chosen, and said unto them: Remember the words which I have spoken. For behold, ye are they whom I have chosen to minister unto this people. Therefore I say unto you, take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
+
 Behold the fowls of the air, for they sow not, neither do they reap nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
+
 Which of you by taking thought can add one cubit unto his stature?
+
 And why take ye thought for raiment? Consider the lilies of the field how they grow; they toil not, neither do they spin;
+
 And yet I say unto you, that even Solomon, in all his glory, was not arrayed like one of these.
+
 Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, even so will he clothe you, if ye are not of little faith.
+
 Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
+
 For your heavenly Father knoweth that ye have need of all these things.
+
 But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
+
 Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.
+
 And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
+
 For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
+
 And why beholdest thou the mote that is in thy brother’s eye, but considerest not the beam that is in thine own eye?
+
 Or how wilt thou say to thy brother: Let me pull the mote out of thine eye—and behold, a beam is in thine own eye?
+
 Thou hypocrite, first cast the beam out of thine own eye; and then shalt thou see clearly to cast the mote out of thy brother’s eye.
+
 Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
+
 Ask, and it shall be given unto you; seek, and ye shall find; knock, and it shall be opened unto you.
+
 For every one that asketh, receiveth; and he that seeketh, findeth; and to him that knocketh, it shall be opened.
+
 Or what man is there of you, who, if his son ask bread, will give him a stone?
+
 Or if he ask a fish, will he give him a serpent?
+
 If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father who is in heaven give good things to them that ask him?
+
 Therefore, all things whatsoever ye would that men should do to you, do ye even so to them, for this is the law and the prophets.
+
 Enter ye in at the strait gate; for wide is the gate, and broad is the way, which leadeth to destruction, and many there be who go in thereat;
+
 Because strait is the gate, and narrow is the way, which leadeth unto life, and few there be that find it.
+
 Beware of false prophets, who come to you in sheep’s clothing, but inwardly they are ravening wolves.
+
 Ye shall know them by their fruits. Do men gather grapes of thorns, or figs of thistles?
 
 Even so every good tree bringeth forth good fruit; but a corrupt tree bringeth forth evil fruit.
+
 A good tree cannot bring forth evil fruit, neither a corrupt tree bring forth good fruit.
+
 Every tree that bringeth not forth good fruit is hewn down, and cast into the fire.
+
 Wherefore, by their fruits ye shall know them.
+
 Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father who is in heaven.
+
 Many will say to me in that day: Lord, Lord, have we not prophesied in thy name, and in thy name have cast out devils, and in thy name done many wonderful works?
+
 And then will I profess unto them: I never knew you; depart from me, ye that work iniquity.
+
 Therefore, whoso heareth these sayings of mine and doeth them, I will liken him unto a wise man, who built his house upon a rock—
+
 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not, for it was founded upon a rock.
+
 And every one that heareth these sayings of mine and doeth them not shall be likened unto a foolish man, who built his house upon the sand—
+
 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell, and great was the fall of it.

--- a/sermon-mount.txt
+++ b/sermon-mount.txt
@@ -1,215 +1,108 @@
 And it came to pass that when Jesus had spoken these words unto Nephi, and to those who had been called, (now the number of them who had been called, and received power and authority to baptize, was twelve) and behold, he stretched forth his hand unto the multitude, and cried unto them, saying: Blessed are ye if ye shall give heed unto the words of these twelve whom I have chosen from among you to minister unto you, and to be your servants; and unto them I have given power that they may baptize you with water; and after that ye are baptized with water, behold, I will baptize you with fire and with the Holy Ghost; therefore blessed are ye if ye shall believe in me and be baptized, after that ye have seen me and know that I am.
-
 And again, more blessed are they who shall believe in your words because that ye shall testify that ye have seen me, and that ye know that I am. Yea, blessed are they who shall believe in your words, and come down into the depths of humility and be baptized, for they shall be visited with fire and with the Holy Ghost, and shall receive a remission of their sins.
-
 Yea, blessed are the poor in spirit who come unto me, for theirs is the kingdom of heaven.
-
 And again, blessed are all they that mourn, for they shall be comforted.
-
 And blessed are the meek, for they shall inherit the earth.
-
 And blessed are all they who do hunger and thirst after righteousness, for they shall be filled with the Holy Ghost.
-
 And blessed are the merciful, for they shall obtain mercy.
-
 And blessed are all the pure in heart, for they shall see God.
-
 And blessed are all the peacemakers, for they shall be called the children of God.
-
 And blessed are all they who are persecuted for my name’s sake, for theirs is the kingdom of heaven.
-
 And blessed are ye when men shall revile you and persecute, and shall say all manner of evil against you falsely, for my sake;
-
 For ye shall have great joy and be exceedingly glad, for great shall be your reward in heaven; for so persecuted they the prophets who were before you.
-
 Verily, verily, I say unto you, I give unto you to be the salt of the earth; but if the salt shall lose its savor wherewith shall the earth be salted? The salt shall be thenceforth good for nothing, but to be cast out and to be trodden under foot of men.
-
 Verily, verily, I say unto you, I give unto you to be the light of this people. A city that is set on a hill cannot be hid.
-
 Behold, do men light a candle and put it under a bushel? Nay, but on a candlestick, and it giveth light to all that are in the house;
-
 Therefore let your light so shine before this people, that they may see your good works and glorify your Father who is in heaven.
-
 Think not that I am come to destroy the law or the prophets. I am not come to destroy but to fulfil;
-
 For verily I say unto you, one jot nor one tittle hath not passed away from the law, but in me it hath all been fulfilled.
-
 And behold, I have given you the law and the commandments of my Father, that ye shall believe in me, and that ye shall repent of your sins, and come unto me with a broken heart and a contrite spirit. Behold, ye have the commandments before you, and the law is fulfilled.
-
 Therefore come unto me and be ye saved; for verily I say unto you, that except ye shall keep my commandments, which I have commanded you at this time, ye shall in no case enter into the kingdom of heaven.
-
 Ye have heard that it hath been said by them of old time, and it is also written before you, that thou shalt not kill, and whosoever shall kill shall be in danger of the judgment of God;
-
 But I say unto you, that whosoever is angry with his brother shall be in danger of his judgment. And whosoever shall say to his brother, Raca, shall be in danger of the council; and whosoever shall say, Thou fool, shall be in danger of hell fire.
-
 Therefore, if ye shall come unto me, or shall desire to come unto me, and rememberest that thy brother hath aught against thee—
-
 Go thy way unto thy brother, and first be reconciled to thy brother, and then come unto me with full purpose of heart, and I will receive you.
-
 Agree with thine adversary quickly while thou art in the way with him, lest at any time he shall get thee, and thou shalt be cast into prison.
-
 Verily, verily, I say unto thee, thou shalt by no means come out thence until thou hast paid the uttermost senine. And while ye are in prison can ye pay even one senine? Verily, verily, I say unto you, Nay.
-
 Behold, it is written by them of old time, that thou shalt not commit adultery;
-
 But I say unto you, that whosoever looketh on a woman, to lust after her, hath committed adultery already in his heart.
-
 Behold, I give unto you a commandment, that ye suffer none of these things to enter into your heart;
-
 For it is better that ye should deny yourselves of these things, wherein ye will take up your cross, than that ye should be cast into hell.
-
 It hath been written, that whosoever shall put away his wife, let him give her a writing of divorcement.
-
 Verily, verily, I say unto you, that whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery; and whoso shall marry her who is divorced committeth adultery.
-
 And again it is written, thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths;
-
 But verily, verily, I say unto you, swear not at all; neither by heaven, for it is God’s throne;
-
 Nor by the earth, for it is his footstool;
-
 Neither shalt thou swear by thy head, because thou canst not make one hair black or white;
-
 But let your communication be Yea, yea; Nay, nay; for whatsoever cometh of more than these is evil.
-
 And behold, it is written, an eye for an eye, and a tooth for a tooth;
-
 But I say unto you, that ye shall not resist evil, but whosoever shall smite thee on thy right cheek, turn to him the other also;
-
 And if any man will sue thee at the law and take away thy coat, let him have thy cloak also;
-
 And whosoever shall compel thee to go a mile, go with him twain.
-
 Give to him that asketh thee, and from him that would borrow of thee turn thou not away.
-
 And behold it is written also, that thou shalt love thy neighbor and hate thine enemy;
-
 But behold I say unto you, love your enemies, bless them that curse you, do good to them that hate you, and pray for them who despitefully use you and persecute you;
-
 That ye may be the children of your Father who is in heaven; for he maketh his sun to rise on the evil and on the good.
-
 Therefore those things which were of old time, which were under the law, in me are all fulfilled.
-
 Old things are done away, and all things have become new.
-
 Therefore I would that ye should be perfect even as I, or your Father who is in heaven is perfect. Verily, verily, I say that I would that ye should do alms unto the poor; but take heed that ye do not your alms before men to be seen of them; otherwise ye have no reward of your Father who is in heaven.
-
 Therefore, when ye shall do your alms do not sound a trumpet before you, as will hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, they have their reward.
-
 But when thou doest alms let not thy left hand know what thy right hand doeth;
-
 That thine alms may be in secret; and thy Father who seeth in secret, himself shall reward thee openly.
-
 And when thou prayest thou shalt not do as the hypocrites, for they love to pray, standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, they have their reward.
-
 But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
-
 But when ye pray, use not vain repetitions, as the heathen, for they think that they shall be heard for their much speaking.
-
 Be not ye therefore like unto them, for your Father knoweth what things ye have need of before ye ask him.
-
 After this manner therefore pray ye: Our Father who art in heaven, hallowed be thy name.
-
 Thy will be done on earth as it is in heaven.
-
 And forgive us our debts, as we forgive our debtors.
-
 And lead us not into temptation, but deliver us from evil.
-
 For thine is the kingdom, and the power, and the glory, forever. Amen.
-
 For, if ye forgive men their trespasses your heavenly Father will also forgive you;
-
 But if ye forgive not men their trespasses neither will your Father forgive your trespasses.
-
 Moreover, when ye fast be not as the hypocrites, of a sad countenance, for they disfigure their faces that they may appear unto men to fast. Verily I say unto you, they have their reward.
-
 But thou, when thou fastest, anoint thy head, and wash thy face;
-
 That thou appear not unto men to fast, but unto thy Father, who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
-
 Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and thieves break through and steal;
-
 But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal.
-
 For where your treasure is, there will your heart be also.
-
 The light of the body is the eye; if, therefore, thine eye be single, thy whole body shall be full of light.
-
 But if thine eye be evil, thy whole body shall be full of darkness. If, therefore, the light that is in thee be darkness, how great is that darkness!
-
 No man can serve two masters; for either he will hate the one and love the other, or else he will hold to the one and despise the other. Ye cannot serve God and Mammon.
-
 And now it came to pass that when Jesus had spoken these words he looked upon the twelve whom he had chosen, and said unto them: Remember the words which I have spoken. For behold, ye are they whom I have chosen to minister unto this people. Therefore I say unto you, take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
-
 Behold the fowls of the air, for they sow not, neither do they reap nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
-
 Which of you by taking thought can add one cubit unto his stature?
-
 And why take ye thought for raiment? Consider the lilies of the field how they grow; they toil not, neither do they spin;
-
 And yet I say unto you, that even Solomon, in all his glory, was not arrayed like one of these.
-
 Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, even so will he clothe you, if ye are not of little faith.
-
 Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
-
 For your heavenly Father knoweth that ye have need of all these things.
-
 But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
-
 Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.
-
 And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
-
 For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
-
 And why beholdest thou the mote that is in thy brother’s eye, but considerest not the beam that is in thine own eye?
-
 Or how wilt thou say to thy brother: Let me pull the mote out of thine eye—and behold, a beam is in thine own eye?
-
 Thou hypocrite, first cast the beam out of thine own eye; and then shalt thou see clearly to cast the mote out of thy brother’s eye.
-
 Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
-
 Ask, and it shall be given unto you; seek, and ye shall find; knock, and it shall be opened unto you.
-
 For every one that asketh, receiveth; and he that seeketh, findeth; and to him that knocketh, it shall be opened.
-
 Or what man is there of you, who, if his son ask bread, will give him a stone?
-
 Or if he ask a fish, will he give him a serpent?
-
 If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father who is in heaven give good things to them that ask him?
-
 Therefore, all things whatsoever ye would that men should do to you, do ye even so to them, for this is the law and the prophets.
-
 Enter ye in at the strait gate; for wide is the gate, and broad is the way, which leadeth to destruction, and many there be who go in thereat;
-
 Because strait is the gate, and narrow is the way, which leadeth unto life, and few there be that find it.
-
 Beware of false prophets, who come to you in sheep’s clothing, but inwardly they are ravening wolves.
-
 Ye shall know them by their fruits. Do men gather grapes of thorns, or figs of thistles?
-
 Even so every good tree bringeth forth good fruit; but a corrupt tree bringeth forth evil fruit.
-
 A good tree cannot bring forth evil fruit, neither a corrupt tree bring forth good fruit.
-
 Every tree that bringeth not forth good fruit is hewn down, and cast into the fire.
-
 Wherefore, by their fruits ye shall know them.
-
 Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father who is in heaven.
-
 Many will say to me in that day: Lord, Lord, have we not prophesied in thy name, and in thy name have cast out devils, and in thy name done many wonderful works?
-
 And then will I profess unto them: I never knew you; depart from me, ye that work iniquity.
-
 Therefore, whoso heareth these sayings of mine and doeth them, I will liken him unto a wise man, who built his house upon a rock—
-
 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not, for it was founded upon a rock.
-
 And every one that heareth these sayings of mine and doeth them not shall be likened unto a foolish man, who built his house upon the sand—
-
 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell, and great was the fall of it.

--- a/sermon-mount.txt
+++ b/sermon-mount.txt
@@ -1,215 +1,215 @@
-1 And it came to pass that when Jesus had spoken these words unto Nephi, and to those who had been called, (now the number of them who had been called, and received power and authority to baptize, was twelve) and behold, he stretched forth his hand unto the multitude, and cried unto them, saying: Blessed are ye if ye shall give heed unto the words of these twelve whom I have chosen from among you to minister unto you, and to be your servants; and unto them I have given power that they may baptize you with water; and after that ye are baptized with water, behold, I will baptize you with fire and with the Holy Ghost; therefore blessed are ye if ye shall believe in me and be baptized, after that ye have seen me and know that I am.
+ And it came to pass that when Jesus had spoken these words unto Nephi, and to those who had been called, (now the number of them who had been called, and received power and authority to baptize, was twelve) and behold, he stretched forth his hand unto the multitude, and cried unto them, saying: Blessed are ye if ye shall give heed unto the words of these twelve whom I have chosen from among you to minister unto you, and to be your servants; and unto them I have given power that they may baptize you with water; and after that ye are baptized with water, behold, I will baptize you with fire and with the Holy Ghost; therefore blessed are ye if ye shall believe in me and be baptized, after that ye have seen me and know that I am.
 
-2 And again, more blessed are they who shall believe in your words because that ye shall testify that ye have seen me, and that ye know that I am. Yea, blessed are they who shall believe in your words, and come down into the depths of humility and be baptized, for they shall be visited with fire and with the Holy Ghost, and shall receive a remission of their sins.
+ And again, more blessed are they who shall believe in your words because that ye shall testify that ye have seen me, and that ye know that I am. Yea, blessed are they who shall believe in your words, and come down into the depths of humility and be baptized, for they shall be visited with fire and with the Holy Ghost, and shall receive a remission of their sins.
 
-3 Yea, blessed are the poor in spirit who come unto me, for theirs is the kingdom of heaven.
+ Yea, blessed are the poor in spirit who come unto me, for theirs is the kingdom of heaven.
 
-4 And again, blessed are all they that mourn, for they shall be comforted.
+ And again, blessed are all they that mourn, for they shall be comforted.
 
-5 And blessed are the meek, for they shall inherit the earth.
+ And blessed are the meek, for they shall inherit the earth.
 
-6 And blessed are all they who do hunger and thirst after righteousness, for they shall be filled with the Holy Ghost.
+ And blessed are all they who do hunger and thirst after righteousness, for they shall be filled with the Holy Ghost.
 
-7 And blessed are the merciful, for they shall obtain mercy.
+ And blessed are the merciful, for they shall obtain mercy.
 
-8 And blessed are all the pure in heart, for they shall see God.
+ And blessed are all the pure in heart, for they shall see God.
 
-9 And blessed are all the peacemakers, for they shall be called the children of God.
+ And blessed are all the peacemakers, for they shall be called the children of God.
 
-10 And blessed are all they who are persecuted for my name’s sake, for theirs is the kingdom of heaven.
+ And blessed are all they who are persecuted for my name’s sake, for theirs is the kingdom of heaven.
 
-11 And blessed are ye when men shall revile you and persecute, and shall say all manner of evil against you falsely, for my sake;
+ And blessed are ye when men shall revile you and persecute, and shall say all manner of evil against you falsely, for my sake;
 
-12 For ye shall have great joy and be exceedingly glad, for great shall be your reward in heaven; for so persecuted they the prophets who were before you.
+ For ye shall have great joy and be exceedingly glad, for great shall be your reward in heaven; for so persecuted they the prophets who were before you.
 
-13 Verily, verily, I say unto you, I give unto you to be the salt of the earth; but if the salt shall lose its savor wherewith shall the earth be salted? The salt shall be thenceforth good for nothing, but to be cast out and to be trodden under foot of men.
+ Verily, verily, I say unto you, I give unto you to be the salt of the earth; but if the salt shall lose its savor wherewith shall the earth be salted? The salt shall be thenceforth good for nothing, but to be cast out and to be trodden under foot of men.
 
-14 Verily, verily, I say unto you, I give unto you to be the light of this people. A city that is set on a hill cannot be hid.
+ Verily, verily, I say unto you, I give unto you to be the light of this people. A city that is set on a hill cannot be hid.
 
-15 Behold, do men light a candle and put it under a bushel? Nay, but on a candlestick, and it giveth light to all that are in the house;
+ Behold, do men light a candle and put it under a bushel? Nay, but on a candlestick, and it giveth light to all that are in the house;
 
-16 Therefore let your light so shine before this people, that they may see your good works and glorify your Father who is in heaven.
+ Therefore let your light so shine before this people, that they may see your good works and glorify your Father who is in heaven.
 
-17 Think not that I am come to destroy the law or the prophets. I am not come to destroy but to fulfil;
+ Think not that I am come to destroy the law or the prophets. I am not come to destroy but to fulfil;
 
-18 For verily I say unto you, one jot nor one tittle hath not passed away from the law, but in me it hath all been fulfilled.
+ For verily I say unto you, one jot nor one tittle hath not passed away from the law, but in me it hath all been fulfilled.
 
-19 And behold, I have given you the law and the commandments of my Father, that ye shall believe in me, and that ye shall repent of your sins, and come unto me with a broken heart and a contrite spirit. Behold, ye have the commandments before you, and the law is fulfilled.
+ And behold, I have given you the law and the commandments of my Father, that ye shall believe in me, and that ye shall repent of your sins, and come unto me with a broken heart and a contrite spirit. Behold, ye have the commandments before you, and the law is fulfilled.
 
-20 Therefore come unto me and be ye saved; for verily I say unto you, that except ye shall keep my commandments, which I have commanded you at this time, ye shall in no case enter into the kingdom of heaven.
+ Therefore come unto me and be ye saved; for verily I say unto you, that except ye shall keep my commandments, which I have commanded you at this time, ye shall in no case enter into the kingdom of heaven.
 
-21 Ye have heard that it hath been said by them of old time, and it is also written before you, that thou shalt not kill, and whosoever shall kill shall be in danger of the judgment of God;
+ Ye have heard that it hath been said by them of old time, and it is also written before you, that thou shalt not kill, and whosoever shall kill shall be in danger of the judgment of God;
 
-22 But I say unto you, that whosoever is angry with his brother shall be in danger of his judgment. And whosoever shall say to his brother, Raca, shall be in danger of the council; and whosoever shall say, Thou fool, shall be in danger of hell fire.
+ But I say unto you, that whosoever is angry with his brother shall be in danger of his judgment. And whosoever shall say to his brother, Raca, shall be in danger of the council; and whosoever shall say, Thou fool, shall be in danger of hell fire.
 
-23 Therefore, if ye shall come unto me, or shall desire to come unto me, and rememberest that thy brother hath aught against thee—
+ Therefore, if ye shall come unto me, or shall desire to come unto me, and rememberest that thy brother hath aught against thee—
 
-24 Go thy way unto thy brother, and first be reconciled to thy brother, and then come unto me with full purpose of heart, and I will receive you.
+ Go thy way unto thy brother, and first be reconciled to thy brother, and then come unto me with full purpose of heart, and I will receive you.
 
-25 Agree with thine adversary quickly while thou art in the way with him, lest at any time he shall get thee, and thou shalt be cast into prison.
+ Agree with thine adversary quickly while thou art in the way with him, lest at any time he shall get thee, and thou shalt be cast into prison.
 
-26 Verily, verily, I say unto thee, thou shalt by no means come out thence until thou hast paid the uttermost senine. And while ye are in prison can ye pay even one senine? Verily, verily, I say unto you, Nay.
+ Verily, verily, I say unto thee, thou shalt by no means come out thence until thou hast paid the uttermost senine. And while ye are in prison can ye pay even one senine? Verily, verily, I say unto you, Nay.
 
-27 Behold, it is written by them of old time, that thou shalt not commit adultery;
+ Behold, it is written by them of old time, that thou shalt not commit adultery;
 
-28 But I say unto you, that whosoever looketh on a woman, to lust after her, hath committed adultery already in his heart.
+ But I say unto you, that whosoever looketh on a woman, to lust after her, hath committed adultery already in his heart.
 
-29 Behold, I give unto you a commandment, that ye suffer none of these things to enter into your heart;
+ Behold, I give unto you a commandment, that ye suffer none of these things to enter into your heart;
 
-30 For it is better that ye should deny yourselves of these things, wherein ye will take up your cross, than that ye should be cast into hell.
+ For it is better that ye should deny yourselves of these things, wherein ye will take up your cross, than that ye should be cast into hell.
 
-31 It hath been written, that whosoever shall put away his wife, let him give her a writing of divorcement.
+ It hath been written, that whosoever shall put away his wife, let him give her a writing of divorcement.
 
-32 Verily, verily, I say unto you, that whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery; and whoso shall marry her who is divorced committeth adultery.
+ Verily, verily, I say unto you, that whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery; and whoso shall marry her who is divorced committeth adultery.
 
-33 And again it is written, thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths;
+ And again it is written, thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths;
 
-34 But verily, verily, I say unto you, swear not at all; neither by heaven, for it is God’s throne;
+ But verily, verily, I say unto you, swear not at all; neither by heaven, for it is God’s throne;
 
-35 Nor by the earth, for it is his footstool;
+ Nor by the earth, for it is his footstool;
 
-36 Neither shalt thou swear by thy head, because thou canst not make one hair black or white;
+ Neither shalt thou swear by thy head, because thou canst not make one hair black or white;
 
-37 But let your communication be Yea, yea; Nay, nay; for whatsoever cometh of more than these is evil.
+ But let your communication be Yea, yea; Nay, nay; for whatsoever cometh of more than these is evil.
 
-38 And behold, it is written, an eye for an eye, and a tooth for a tooth;
+ And behold, it is written, an eye for an eye, and a tooth for a tooth;
 
-39 But I say unto you, that ye shall not resist evil, but whosoever shall smite thee on thy right cheek, turn to him the other also;
+ But I say unto you, that ye shall not resist evil, but whosoever shall smite thee on thy right cheek, turn to him the other also;
 
-40 And if any man will sue thee at the law and take away thy coat, let him have thy cloak also;
+ And if any man will sue thee at the law and take away thy coat, let him have thy cloak also;
 
-41 And whosoever shall compel thee to go a mile, go with him twain.
+ And whosoever shall compel thee to go a mile, go with him twain.
 
-42 Give to him that asketh thee, and from him that would borrow of thee turn thou not away.
+ Give to him that asketh thee, and from him that would borrow of thee turn thou not away.
 
-43 And behold it is written also, that thou shalt love thy neighbor and hate thine enemy;
+ And behold it is written also, that thou shalt love thy neighbor and hate thine enemy;
 
-44 But behold I say unto you, love your enemies, bless them that curse you, do good to them that hate you, and pray for them who despitefully use you and persecute you;
+ But behold I say unto you, love your enemies, bless them that curse you, do good to them that hate you, and pray for them who despitefully use you and persecute you;
 
-45 That ye may be the children of your Father who is in heaven; for he maketh his sun to rise on the evil and on the good.
+ That ye may be the children of your Father who is in heaven; for he maketh his sun to rise on the evil and on the good.
 
-46 Therefore those things which were of old time, which were under the law, in me are all fulfilled.
+ Therefore those things which were of old time, which were under the law, in me are all fulfilled.
 
-47 Old things are done away, and all things have become new.
+ Old things are done away, and all things have become new.
 
-48 Therefore I would that ye should be perfect even as I, or your Father who is in heaven is perfect.1 Verily, verily, I say that I would that ye should do alms unto the poor; but take heed that ye do not your alms before men to be seen of them; otherwise ye have no reward of your Father who is in heaven.
+ Therefore I would that ye should be perfect even as I, or your Father who is in heaven is perfect. Verily, verily, I say that I would that ye should do alms unto the poor; but take heed that ye do not your alms before men to be seen of them; otherwise ye have no reward of your Father who is in heaven.
 
-2 Therefore, when ye shall do your alms do not sound a trumpet before you, as will hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, they have their reward.
+ Therefore, when ye shall do your alms do not sound a trumpet before you, as will hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, they have their reward.
 
-3 But when thou doest alms let not thy left hand know what thy right hand doeth;
+ But when thou doest alms let not thy left hand know what thy right hand doeth;
 
-4 That thine alms may be in secret; and thy Father who seeth in secret, himself shall reward thee openly.
+ That thine alms may be in secret; and thy Father who seeth in secret, himself shall reward thee openly.
 
-5 And when thou prayest thou shalt not do as the hypocrites, for they love to pray, standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, they have their reward.
+ And when thou prayest thou shalt not do as the hypocrites, for they love to pray, standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, they have their reward.
 
-6 But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
+ But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
 
-7 But when ye pray, use not vain repetitions, as the heathen, for they think that they shall be heard for their much speaking.
+ But when ye pray, use not vain repetitions, as the heathen, for they think that they shall be heard for their much speaking.
 
-8 Be not ye therefore like unto them, for your Father knoweth what things ye have need of before ye ask him.
+ Be not ye therefore like unto them, for your Father knoweth what things ye have need of before ye ask him.
 
-9 After this manner therefore pray ye: Our Father who art in heaven, hallowed be thy name.
+ After this manner therefore pray ye: Our Father who art in heaven, hallowed be thy name.
 
-10 Thy will be done on earth as it is in heaven.
+ Thy will be done on earth as it is in heaven.
 
-11 And forgive us our debts, as we forgive our debtors.
+ And forgive us our debts, as we forgive our debtors.
 
-12 And lead us not into temptation, but deliver us from evil.
+ And lead us not into temptation, but deliver us from evil.
 
-13 For thine is the kingdom, and the power, and the glory, forever. Amen.
+ For thine is the kingdom, and the power, and the glory, forever. Amen.
 
-14 For, if ye forgive men their trespasses your heavenly Father will also forgive you;
+ For, if ye forgive men their trespasses your heavenly Father will also forgive you;
 
-15 But if ye forgive not men their trespasses neither will your Father forgive your trespasses.
+ But if ye forgive not men their trespasses neither will your Father forgive your trespasses.
 
-16 Moreover, when ye fast be not as the hypocrites, of a sad countenance, for they disfigure their faces that they may appear unto men to fast. Verily I say unto you, they have their reward.
+ Moreover, when ye fast be not as the hypocrites, of a sad countenance, for they disfigure their faces that they may appear unto men to fast. Verily I say unto you, they have their reward.
 
-17 But thou, when thou fastest, anoint thy head, and wash thy face;
+ But thou, when thou fastest, anoint thy head, and wash thy face;
 
-18 That thou appear not unto men to fast, but unto thy Father, who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
+ That thou appear not unto men to fast, but unto thy Father, who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
 
-19 Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and thieves break through and steal;
+ Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and thieves break through and steal;
 
-20 But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal.
+ But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal.
 
-21 For where your treasure is, there will your heart be also.
+ For where your treasure is, there will your heart be also.
 
-22 The light of the body is the eye; if, therefore, thine eye be single, thy whole body shall be full of light.
+ The light of the body is the eye; if, therefore, thine eye be single, thy whole body shall be full of light.
 
-23 But if thine eye be evil, thy whole body shall be full of darkness. If, therefore, the light that is in thee be darkness, how great is that darkness!
+ But if thine eye be evil, thy whole body shall be full of darkness. If, therefore, the light that is in thee be darkness, how great is that darkness!
 
-24 No man can serve two masters; for either he will hate the one and love the other, or else he will hold to the one and despise the other. Ye cannot serve God and Mammon.
+ No man can serve two masters; for either he will hate the one and love the other, or else he will hold to the one and despise the other. Ye cannot serve God and Mammon.
 
-25 And now it came to pass that when Jesus had spoken these words he looked upon the twelve whom he had chosen, and said unto them: Remember the words which I have spoken. For behold, ye are they whom I have chosen to minister unto this people. Therefore I say unto you, take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
+ And now it came to pass that when Jesus had spoken these words he looked upon the twelve whom he had chosen, and said unto them: Remember the words which I have spoken. For behold, ye are they whom I have chosen to minister unto this people. Therefore I say unto you, take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
 
-26 Behold the fowls of the air, for they sow not, neither do they reap nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
+ Behold the fowls of the air, for they sow not, neither do they reap nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
 
-27 Which of you by taking thought can add one cubit unto his stature?
+ Which of you by taking thought can add one cubit unto his stature?
 
-28 And why take ye thought for raiment? Consider the lilies of the field how they grow; they toil not, neither do they spin;
+ And why take ye thought for raiment? Consider the lilies of the field how they grow; they toil not, neither do they spin;
 
-29 And yet I say unto you, that even Solomon, in all his glory, was not arrayed like one of these.
+ And yet I say unto you, that even Solomon, in all his glory, was not arrayed like one of these.
 
-30 Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, even so will he clothe you, if ye are not of little faith.
+ Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, even so will he clothe you, if ye are not of little faith.
 
-31 Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
+ Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
 
-32 For your heavenly Father knoweth that ye have need of all these things.
+ For your heavenly Father knoweth that ye have need of all these things.
 
-33 But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
+ But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
 
-34 Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.
+ Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.
 
-1 And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
+ And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
 
-2 For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
+ For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
 
-3 And why beholdest thou the mote that is in thy brother’s eye, but considerest not the beam that is in thine own eye?
+ And why beholdest thou the mote that is in thy brother’s eye, but considerest not the beam that is in thine own eye?
 
-4 Or how wilt thou say to thy brother: Let me pull the mote out of thine eye—and behold, a beam is in thine own eye?
+ Or how wilt thou say to thy brother: Let me pull the mote out of thine eye—and behold, a beam is in thine own eye?
 
-5 Thou hypocrite, first cast the beam out of thine own eye; and then shalt thou see clearly to cast the mote out of thy brother’s eye.
+ Thou hypocrite, first cast the beam out of thine own eye; and then shalt thou see clearly to cast the mote out of thy brother’s eye.
 
-6 Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
+ Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
 
-7 Ask, and it shall be given unto you; seek, and ye shall find; knock, and it shall be opened unto you.
+ Ask, and it shall be given unto you; seek, and ye shall find; knock, and it shall be opened unto you.
 
-8 For every one that asketh, receiveth; and he that seeketh, findeth; and to him that knocketh, it shall be opened.
+ For every one that asketh, receiveth; and he that seeketh, findeth; and to him that knocketh, it shall be opened.
 
-9 Or what man is there of you, who, if his son ask bread, will give him a stone?
+ Or what man is there of you, who, if his son ask bread, will give him a stone?
 
-10 Or if he ask a fish, will he give him a serpent?
+ Or if he ask a fish, will he give him a serpent?
 
-11 If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father who is in heaven give good things to them that ask him?
+ If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father who is in heaven give good things to them that ask him?
 
-12 Therefore, all things whatsoever ye would that men should do to you, do ye even so to them, for this is the law and the prophets.
+ Therefore, all things whatsoever ye would that men should do to you, do ye even so to them, for this is the law and the prophets.
 
-13 Enter ye in at the strait gate; for wide is the gate, and broad is the way, which leadeth to destruction, and many there be who go in thereat;
+ Enter ye in at the strait gate; for wide is the gate, and broad is the way, which leadeth to destruction, and many there be who go in thereat;
 
-14 Because strait is the gate, and narrow is the way, which leadeth unto life, and few there be that find it.
+ Because strait is the gate, and narrow is the way, which leadeth unto life, and few there be that find it.
 
-15 Beware of false prophets, who come to you in sheep’s clothing, but inwardly they are ravening wolves.
+ Beware of false prophets, who come to you in sheep’s clothing, but inwardly they are ravening wolves.
 
-16 Ye shall know them by their fruits. Do men gather grapes of thorns, or figs of thistles?
+ Ye shall know them by their fruits. Do men gather grapes of thorns, or figs of thistles?
 
-17 Even so every good tree bringeth forth good fruit; but a corrupt tree bringeth forth evil fruit.
+ Even so every good tree bringeth forth good fruit; but a corrupt tree bringeth forth evil fruit.
 
-18 A good tree cannot bring forth evil fruit, neither a corrupt tree bring forth good fruit.
+ A good tree cannot bring forth evil fruit, neither a corrupt tree bring forth good fruit.
 
-19 Every tree that bringeth not forth good fruit is hewn down, and cast into the fire.
+ Every tree that bringeth not forth good fruit is hewn down, and cast into the fire.
 
-20 Wherefore, by their fruits ye shall know them.
+ Wherefore, by their fruits ye shall know them.
 
-21 Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father who is in heaven.
+ Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father who is in heaven.
 
-22 Many will say to me in that day: Lord, Lord, have we not prophesied in thy name, and in thy name have cast out devils, and in thy name done many wonderful works?
+ Many will say to me in that day: Lord, Lord, have we not prophesied in thy name, and in thy name have cast out devils, and in thy name done many wonderful works?
 
-23 And then will I profess unto them: I never knew you; depart from me, ye that work iniquity.
+ And then will I profess unto them: I never knew you; depart from me, ye that work iniquity.
 
-24 Therefore, whoso heareth these sayings of mine and doeth them, I will liken him unto a wise man, who built his house upon a rock—
+ Therefore, whoso heareth these sayings of mine and doeth them, I will liken him unto a wise man, who built his house upon a rock—
 
-25 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not, for it was founded upon a rock.
+ And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not, for it was founded upon a rock.
 
-26 And every one that heareth these sayings of mine and doeth them not shall be likened unto a foolish man, who built his house upon the sand—
+ And every one that heareth these sayings of mine and doeth them not shall be likened unto a foolish man, who built his house upon the sand—
 
-27 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell, and great was the fall of it.
+ And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell, and great was the fall of it.

--- a/sermon-mount.txt
+++ b/sermon-mount.txt
@@ -1,217 +1,213 @@
-1 And seeing the multitudes, he went up into a mountain: and when he was set, his disciples came unto him:
+1 And it came to pass that when Jesus had spoken these words unto Nephi, and to those who had been called, (now the number of them who had been called, and received power and authority to baptize, was twelve) and behold, he stretched forth his hand unto the multitude, and cried unto them, saying: Blessed are ye if ye shall give heed unto the words of these twelve whom I have chosen from among you to minister unto you, and to be your servants; and unto them I have given power that they may baptize you with water; and after that ye are baptized with water, behold, I will baptize you with fire and with the Holy Ghost; therefore blessed are ye if ye shall believe in me and be baptized, after that ye have seen me and know that I am.
 
-2 And he opened his mouth, and taught them, saying,
+2 And again, more blessed are they who shall believe in your words because that ye shall testify that ye have seen me, and that ye know that I am. Yea, blessed are they who shall believe in your words, and come down into the depths of humility and be baptized, for they shall be visited with fire and with the Holy Ghost, and shall receive a remission of their sins.
 
-3 Blessed are the poor in spirit: for theirs is the kingdom of heaven.
+3 Yea, blessed are the poor in spirit who come unto me, for theirs is the kingdom of heaven.
 
-4 Blessed are they that mourn: for they shall be comforted.
+4 And again, blessed are all they that mourn, for they shall be comforted.
 
-5 Blessed are the meek: for they shall inherit the earth.
+5 And blessed are the meek, for they shall inherit the earth.
 
-6 Blessed are they which do hunger and thirst after righteousness: for they shall be filled.
+6 And blessed are all they who do hunger and thirst after righteousness, for they shall be filled with the Holy Ghost.
 
-7 Blessed are the merciful: for they shall obtain mercy.
+7 And blessed are the merciful, for they shall obtain mercy.
 
-8 Blessed are the pure in heart: for they shall see God.
+8 And blessed are all the pure in heart, for they shall see God.
 
-9 Blessed are the peacemakers: for they shall be called the children of God.
+9 And blessed are all the peacemakers, for they shall be called the children of God.
 
-10 Blessed are they which are persecuted for righteousness’ sake: for theirs is the kingdom of heaven.
+10 And blessed are all they who are persecuted for my name’s sake, for theirs is the kingdom of heaven.
 
-11 Blessed are ye, when men shall revile you, and persecute you, and shall say all manner of evil against you falsely, for my sake.
+11 And blessed are ye when men shall revile you and persecute, and shall say all manner of evil against you falsely, for my sake;
 
-12 Rejoice, and be exceeding glad: for great is your reward in heaven: for so persecuted they the prophets which were before you.
+12 For ye shall have great joy and be exceedingly glad, for great shall be your reward in heaven; for so persecuted they the prophets who were before you.
 
-13 ¶ Ye are the salt of the earth: but if the salt have lost his savour, wherewith shall it be salted? it is thenceforth good for nothing, but to be cast out, and to be trodden under foot of men.
+13 Verily, verily, I say unto you, I give unto you to be the salt of the earth; but if the salt shall lose its savor wherewith shall the earth be salted? The salt shall be thenceforth good for nothing, but to be cast out and to be trodden under foot of men.
 
-14 Ye are the light of the world. A city that is set on an hill cannot be hid.
+14 Verily, verily, I say unto you, I give unto you to be the light of this people. A city that is set on a hill cannot be hid.
 
-15 Neither do men light a candle, and put it under a bushel, but on a candlestick; and it giveth light unto all that are in the house.
+15 Behold, do men light a candle and put it under a bushel? Nay, but on a candlestick, and it giveth light to all that are in the house;
 
-16 Let your light so shine before men, that they may see your good works, and glorify your Father which is in heaven.
+16 Therefore let your light so shine before this people, that they may see your good works and glorify your Father who is in heaven.
 
-17 ¶ Think not that I am come to destroy the law, or the prophets: I am not come to destroy, but to fulfil.
+17 Think not that I am come to destroy the law or the prophets. I am not come to destroy but to fulfil;
 
-18 For verily I say unto you, Till heaven and earth pass, one jot or one tittle shall in no wise pass from the law, till all be fulfilled.
+18 For verily I say unto you, one jot nor one tittle hath not passed away from the law, but in me it hath all been fulfilled.
 
-19 Whosoever therefore shall break one of these least commandments, and shall teach men so, he shall be called the least in the kingdom of heaven: but whosoever shall do and teach them, the same shall be called great in the kingdom of heaven.
+19 And behold, I have given you the law and the commandments of my Father, that ye shall believe in me, and that ye shall repent of your sins, and come unto me with a broken heart and a contrite spirit. Behold, ye have the commandments before you, and the law is fulfilled.
 
-20 For I say unto you, That except your righteousness shall exceed the righteousness of the scribes and Pharisees, ye shall in no case enter into the kingdom of heaven.
+20 Therefore come unto me and be ye saved; for verily I say unto you, that except ye shall keep my commandments, which I have commanded you at this time, ye shall in no case enter into the kingdom of heaven.
 
-21 ¶ Ye have heard that it was said by them of old time, Thou shalt not kill; and whosoever shall kill shall be in danger of the judgment:
+21 Ye have heard that it hath been said by them of old time, and it is also written before you, that thou shalt not kill, and whosoever shall kill shall be in danger of the judgment of God;
 
-22 But I say unto you, That whosoever is angry with his brother without a cause shall be in danger of the judgment: and whosoever shall say to his brother, Raca, shall be in danger of the council: but whosoever shall say, Thou fool, shall be in danger of hell fire.
+22 But I say unto you, that whosoever is angry with his brother shall be in danger of his judgment. And whosoever shall say to his brother, Raca, shall be in danger of the council; and whosoever shall say, Thou fool, shall be in danger of hell fire.
 
-23 Therefore if thou bring thy gift to the altar, and there rememberest that thy brother hath ought against thee;
+23 Therefore, if ye shall come unto me, or shall desire to come unto me, and rememberest that thy brother hath aught against thee—
 
-24 Leave there thy gift before the altar, and go thy way; first be reconciled to thy brother, and then come and offer thy gift.
+24 Go thy way unto thy brother, and first be reconciled to thy brother, and then come unto me with full purpose of heart, and I will receive you.
 
-25 Agree with thine adversary quickly, whiles thou art in the way with him; lest at any time the adversary deliver thee to the judge, and the judge deliver thee to the officer, and thou be cast into prison.
+25 Agree with thine adversary quickly while thou art in the way with him, lest at any time he shall get thee, and thou shalt be cast into prison.
 
-26 Verily I say unto thee, Thou shalt by no means come out thence, till thou hast paid the uttermost farthing.
+26 Verily, verily, I say unto thee, thou shalt by no means come out thence until thou hast paid the uttermost senine. And while ye are in prison can ye pay even one senine? Verily, verily, I say unto you, Nay.
 
-27 ¶ Ye have heard that it was said by them of old time, Thou shalt not commit adultery:
+27 Behold, it is written by them of old time, that thou shalt not commit adultery;
 
-28 But I say unto you, That whosoever looketh on a woman to lust after her hath committed adultery with her already in his heart.
+28 But I say unto you, that whosoever looketh on a woman, to lust after her, hath committed adultery already in his heart.
 
-29 And if thy right eye offend thee, pluck it out, and cast it from thee: for it is profitable for thee that one of thy members should perish, and not that thy whole body should be cast into hell.
+29 Behold, I give unto you a commandment, that ye suffer none of these things to enter into your heart;
 
-30 And if thy right hand offend thee, cut it off, and cast it from thee: for it is profitable for thee that one of thy members should perish, and not that thy whole body should be cast into hell.
+30 For it is better that ye should deny yourselves of these things, wherein ye will take up your cross, than that ye should be cast into hell.
 
-31 It hath been said, Whosoever shall put away his wife, let him give her a writing of divorcement:
+31 It hath been written, that whosoever shall put away his wife, let him give her a writing of divorcement.
 
-32 But I say unto you, That whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery: and whosoever shall marry her that is divorced committeth adultery.
+32 Verily, verily, I say unto you, that whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery; and whoso shall marry her who is divorced committeth adultery.
 
-33 ¶ Again, ye have heard that it hath been said by them of old time, Thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths:
+33 And again it is written, thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths;
 
-34 But I say unto you, Swear not at all; neither by heaven; for it is God’s throne:
+34 But verily, verily, I say unto you, swear not at all; neither by heaven, for it is God’s throne;
 
-35 Nor by the earth; for it is his footstool: neither by Jerusalem; for it is the city of the great King.
+35 Nor by the earth, for it is his footstool;
 
-36 Neither shalt thou swear by thy head, because thou canst not make one hair white or black.
+36 Neither shalt thou swear by thy head, because thou canst not make one hair black or white;
 
-37 But let your communication be, Yea, yea; Nay, nay: for whatsoever is more than these cometh of evil.
+37 But let your communication be Yea, yea; Nay, nay; for whatsoever cometh of more than these is evil.
 
-38 ¶ Ye have heard that it hath been said, An eye for an eye, and a tooth for a tooth:
+38 And behold, it is written, an eye for an eye, and a tooth for a tooth;
 
-39 But I say unto you, That ye resist not evil: but whosoever shall smite thee on thy right cheek, turn to him the other also.
+39 But I say unto you, that ye shall not resist evil, but whosoever shall smite thee on thy right cheek, turn to him the other also;
 
-40 And if any man will sue thee at the law, and take away thy coat, let him have thy cloak also.
+40 And if any man will sue thee at the law and take away thy coat, let him have thy cloak also;
 
 41 And whosoever shall compel thee to go a mile, go with him twain.
 
-42 Give to him that asketh thee, and from him that would borrow of thee turn not thou away.
+42 Give to him that asketh thee, and from him that would borrow of thee turn thou not away.
 
-43 ¶ Ye have heard that it hath been said, Thou shalt love thy neighbour, and hate thine enemy.
+43 And behold it is written also, that thou shalt love thy neighbor and hate thine enemy;
 
-44 But I say unto you, Love your enemies, bless them that curse you, do good to them that hate you, and pray for them which despitefully use you, and persecute you;
+44 But behold I say unto you, love your enemies, bless them that curse you, do good to them that hate you, and pray for them who despitefully use you and persecute you;
 
-45 That ye may be the children of your Father which is in heaven: for he maketh his sun to rise on the evil and on the good, and sendeth rain on the just and on the unjust.
+45 That ye may be the children of your Father who is in heaven; for he maketh his sun to rise on the evil and on the good.
 
-46 For if ye love them which love you, what reward have ye? do not even the publicans the same?
+46 Therefore those things which were of old time, which were under the law, in me are all fulfilled.
 
-47 And if ye salute your brethren only, what do ye more than others? do not even the publicans so?
+47 Old things are done away, and all things have become new.
 
-48 Be ye therefore perfect, even as your Father which is in heaven is perfect.1 Take heed that ye do not your alms before men, to be seen of them: otherwise ye have no reward of your Father which is in heaven.
+48 Therefore I would that ye should be perfect even as I, or your Father who is in heaven is perfect.1 Verily, verily, I say that I would that ye should do alms unto the poor; but take heed that ye do not your alms before men to be seen of them; otherwise ye have no reward of your Father who is in heaven.
 
-2 Therefore when thou doest thine alms, do not sound a trumpet before thee, as the hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, They have their reward.
+2 Therefore, when ye shall do your alms do not sound a trumpet before you, as will hypocrites do in the synagogues and in the streets, that they may have glory of men. Verily I say unto you, they have their reward.
 
-3 But when thou doest alms, let not thy left hand know what thy right hand doeth:
+3 But when thou doest alms let not thy left hand know what thy right hand doeth;
 
-4 That thine alms may be in secret: and thy Father which seeth in secret himself shall reward thee openly.
+4 That thine alms may be in secret; and thy Father who seeth in secret, himself shall reward thee openly.
 
-5 ¶ And when thou prayest, thou shalt not be as the hypocrites are: for they love to pray standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, They have their reward.
+5 And when thou prayest thou shalt not do as the hypocrites, for they love to pray, standing in the synagogues and in the corners of the streets, that they may be seen of men. Verily I say unto you, they have their reward.
 
-6 But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father which is in secret; and thy Father which seeth in secret shall reward thee openly.
+6 But thou, when thou prayest, enter into thy closet, and when thou hast shut thy door, pray to thy Father who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
 
-7 But when ye pray, use not vain repetitions, as the heathen do: for they think that they shall be heard for their much speaking.
+7 But when ye pray, use not vain repetitions, as the heathen, for they think that they shall be heard for their much speaking.
 
-8 Be not ye therefore like unto them: for your Father knoweth what things ye have need of, before ye ask him.
+8 Be not ye therefore like unto them, for your Father knoweth what things ye have need of before ye ask him.
 
-9 After this manner therefore pray ye: Our Father which art in heaven, Hallowed be thy name.
+9 After this manner therefore pray ye: Our Father who art in heaven, hallowed be thy name.
 
-10 Thy kingdom come. Thy will be done in earth, as it is in heaven.
+10 Thy will be done on earth as it is in heaven.
 
-11 Give us this day our daily bread.
+11 And forgive us our debts, as we forgive our debtors.
 
-12 And forgive us our debts, as we forgive our debtors.
+12 And lead us not into temptation, but deliver us from evil.
 
-13 And lead us not into temptation, but deliver us from evil: For thine is the kingdom, and the power, and the glory, for ever. Amen.
+13 For thine is the kingdom, and the power, and the glory, forever. Amen.
 
-14 For if ye forgive men their trespasses, your heavenly Father will also forgive you:
+14 For, if ye forgive men their trespasses your heavenly Father will also forgive you;
 
-15 But if ye forgive not men their trespasses, neither will your Father forgive your trespasses.
+15 But if ye forgive not men their trespasses neither will your Father forgive your trespasses.
 
-16 ¶ Moreover when ye fast, be not, as the hypocrites, of a sad countenance: for they disfigure their faces, that they may appear unto men to fast. Verily I say unto you, They have their reward.
+16 Moreover, when ye fast be not as the hypocrites, of a sad countenance, for they disfigure their faces that they may appear unto men to fast. Verily I say unto you, they have their reward.
 
-17 But thou, when thou fastest, anoint thine head, and wash thy face;
+17 But thou, when thou fastest, anoint thy head, and wash thy face;
 
-18 That thou appear not unto men to fast, but unto thy Father which is in secret: and thy Father, which seeth in secret, shall reward thee openly.
+18 That thou appear not unto men to fast, but unto thy Father, who is in secret; and thy Father, who seeth in secret, shall reward thee openly.
 
-19 ¶ Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and where thieves break through and steal:
+19 Lay not up for yourselves treasures upon earth, where moth and rust doth corrupt, and thieves break through and steal;
 
-20 But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal:
+20 But lay up for yourselves treasures in heaven, where neither moth nor rust doth corrupt, and where thieves do not break through nor steal.
 
 21 For where your treasure is, there will your heart be also.
 
-22 The light of the body is the eye: if therefore thine eye be single, thy whole body shall be full of light.
+22 The light of the body is the eye; if, therefore, thine eye be single, thy whole body shall be full of light.
 
-23 But if thine eye be evil, thy whole body shall be full of darkness. If therefore the light that is in thee be darkness, how great is that darkness!
+23 But if thine eye be evil, thy whole body shall be full of darkness. If, therefore, the light that is in thee be darkness, how great is that darkness!
 
-24 ¶ No man can serve two masters: for either he will hate the one, and love the other; or else he will hold to the one, and despise the other. Ye cannot serve God and mammon.
+24 No man can serve two masters; for either he will hate the one and love the other, or else he will hold to the one and despise the other. Ye cannot serve God and Mammon.
 
-25 Therefore I say unto you, Take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
+25 And now it came to pass that when Jesus had spoken these words he looked upon the twelve whom he had chosen, and said unto them: Remember the words which I have spoken. For behold, ye are they whom I have chosen to minister unto this people. Therefore I say unto you, take no thought for your life, what ye shall eat, or what ye shall drink; nor yet for your body, what ye shall put on. Is not the life more than meat, and the body than raiment?
 
-26 Behold the fowls of the air: for they sow not, neither do they reap, nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
+26 Behold the fowls of the air, for they sow not, neither do they reap nor gather into barns; yet your heavenly Father feedeth them. Are ye not much better than they?
 
 27 Which of you by taking thought can add one cubit unto his stature?
 
-28 And why take ye thought for raiment? Consider the lilies of the field, how they grow; they toil not, neither do they spin:
+28 And why take ye thought for raiment? Consider the lilies of the field how they grow; they toil not, neither do they spin;
 
-29 And yet I say unto you, That even Solomon in all his glory was not arrayed like one of these.
+29 And yet I say unto you, that even Solomon, in all his glory, was not arrayed like one of these.
 
-30 Wherefore, if God so clothe the grass of the field, which to day is, and to morrow is cast into the oven, shall he not much more clothe you, O ye of little faith?
+30 Wherefore, if God so clothe the grass of the field, which today is, and tomorrow is cast into the oven, even so will he clothe you, if ye are not of little faith.
 
 31 Therefore take no thought, saying, What shall we eat? or, What shall we drink? or, Wherewithal shall we be clothed?
 
-32 (For after all these things do the Gentiles seek:) for your heavenly Father knoweth that ye have need of all these things.
+32 For your heavenly Father knoweth that ye have need of all these things.
 
-33 But seek ye first the kingdom of God, and his righteousness; and all these things shall be added unto you.
+33 But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
 
-34 Take therefore no thought for the morrow: for the morrow shall take thought for the things of itself. Sufficient unto the day is the evil thereof.1 Judge not, that ye be not judged.
+34 Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.1 And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
 
-2 For with what judgment ye judge, ye shall be judged: and with what measure ye mete, it shall be measured to you again.
+2 For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
 
 3 And why beholdest thou the mote that is in thy brother’s eye, but considerest not the beam that is in thine own eye?
 
-4 Or how wilt thou say to thy brother, Let me pull out the mote out of thine eye; and, behold, a beam is in thine own eye?
+4 Or how wilt thou say to thy brother: Let me pull the mote out of thine eye—and behold, a beam is in thine own eye?
 
-5 Thou hypocrite, first cast out the beam out of thine own eye; and then shalt thou see clearly to cast out the mote out of thy brother’s eye.
+5 Thou hypocrite, first cast the beam out of thine own eye; and then shalt thou see clearly to cast the mote out of thy brother’s eye.
 
-6 ¶ Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
+6 Give not that which is holy unto the dogs, neither cast ye your pearls before swine, lest they trample them under their feet, and turn again and rend you.
 
-7 ¶ Ask, and it shall be given you; seek, and ye shall find; knock, and it shall be opened unto you:
+7 Ask, and it shall be given unto you; seek, and ye shall find; knock, and it shall be opened unto you.
 
-8 For every one that asketh receiveth; and he that seeketh findeth; and to him that knocketh it shall be opened.
+8 For every one that asketh, receiveth; and he that seeketh, findeth; and to him that knocketh, it shall be opened.
 
-9 Or what man is there of you, whom if his son ask bread, will he give him a stone?
+9 Or what man is there of you, who, if his son ask bread, will give him a stone?
 
 10 Or if he ask a fish, will he give him a serpent?
 
-11 If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father which is in heaven give good things to them that ask him?
+11 If ye then, being evil, know how to give good gifts unto your children, how much more shall your Father who is in heaven give good things to them that ask him?
 
-12 Therefore all things whatsoever ye would that men should do to you, do ye even so to them: for this is the law and the prophets.
+12 Therefore, all things whatsoever ye would that men should do to you, do ye even so to them, for this is the law and the prophets.
 
-13 ¶ Enter ye in at the strait gate: for wide is the gate, and broad is the way, that leadeth to destruction, and many there be which go in thereat:
+13 Enter ye in at the strait gate; for wide is the gate, and broad is the way, which leadeth to destruction, and many there be who go in thereat;
 
 14 Because strait is the gate, and narrow is the way, which leadeth unto life, and few there be that find it.
 
-15 ¶ Beware of false prophets, which come to you in sheep’s clothing, but inwardly they are ravening wolves.
+15 Beware of false prophets, who come to you in sheep’s clothing, but inwardly they are ravening wolves.
 
 16 Ye shall know them by their fruits. Do men gather grapes of thorns, or figs of thistles?
 
 17 Even so every good tree bringeth forth good fruit; but a corrupt tree bringeth forth evil fruit.
 
-18 A good tree cannot bring forth evil fruit, neither can a corrupt tree bring forth good fruit.
+18 A good tree cannot bring forth evil fruit, neither a corrupt tree bring forth good fruit.
 
 19 Every tree that bringeth not forth good fruit is hewn down, and cast into the fire.
 
-20 Wherefore by their fruits ye shall know them.
+20 Wherefore, by their fruits ye shall know them.
 
-21 ¶ Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father which is in heaven.
+21 Not every one that saith unto me, Lord, Lord, shall enter into the kingdom of heaven; but he that doeth the will of my Father who is in heaven.
 
-22 Many will say to me in that day, Lord, Lord, have we not prophesied in thy name? and in thy name have cast out devils? and in thy name done many wonderful works?
+22 Many will say to me in that day: Lord, Lord, have we not prophesied in thy name, and in thy name have cast out devils, and in thy name done many wonderful works?
 
-23 And then will I profess unto them, I never knew you: depart from me, ye that work iniquity.
+23 And then will I profess unto them: I never knew you; depart from me, ye that work iniquity.
 
-24 ¶ Therefore whosoever heareth these sayings of mine, and doeth them, I will liken him unto a wise man, which built his house upon a rock:
+24 Therefore, whoso heareth these sayings of mine and doeth them, I will liken him unto a wise man, who built his house upon a rock—
 
-25 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not: for it was founded upon a rock.
+25 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not, for it was founded upon a rock.
 
-26 And every one that heareth these sayings of mine, and doeth them not, shall be likened unto a foolish man, which built his house upon the sand:
+26 And every one that heareth these sayings of mine and doeth them not shall be likened unto a foolish man, who built his house upon the sand—
 
-27 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell: and great was the fall of it.
-
-28 And it came to pass, when Jesus had ended these sayings, the people were astonished at his doctrine:
-
-29 For he taught them as one having authority, and not as the scribes.
+27 And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell, and great was the fall of it.

--- a/sermon-mount.txt
+++ b/sermon-mount.txt
@@ -158,7 +158,9 @@
 
 33 But seek ye first the kingdom of God and his righteousness, and all these things shall be added unto you.
 
-34 Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.1 And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
+34 Take therefore no thought for the morrow, for the morrow shall take thought for the things of itself. Sufficient is the day unto the evil thereof.
+
+1 And now it came to pass that when Jesus had spoken these words he turned again to the multitude, and did open his mouth unto them again, saying: Verily, verily, I say unto you, Judge not, that ye be not judged.
 
 2 For with what judgment ye judge, ye shall be judged; and with what measure ye mete, it shall be measured to you again.
 


### PR DESCRIPTION
There are many similarities but also significant differences between the Sermon on the Mount in Matthew (in the New Testament) and the version in 3 Nephi of the Book of Mormon, more properly called the Sermon on the Temple.

Many have used the similarities to [argue](https://www.ldsdiscussions.com/mount) that the Book of Mormon is simply a fabrication.

However, others have made a [strong case](https://scholarsarchive.byu.edu/mi/89/) that the differences provide evidence of the Book of Mormon's historicity (i.e. that it's true).

I'll let you decide... but please view this diff as your own study guide.

Ultimately, it's up to you to pray about the Book of Mormon after sincerely studying it and pondering it, and see what God himself tells you.  There is no greater joy than receiving the feeling of peace from God and knowing even more surely that Jesus is real, we can be saved, and God still answers prayers.